### PR TITLE
Added bootstrap.sh

### DIFF
--- a/.bootstrap/bootstrap.sh
+++ b/.bootstrap/bootstrap.sh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+set -euo pipefail
+
+echo "[BOOTSTRAP] Starting full bootstrap sequence..."
+
+BOOTSTRAP_DIR="$HOME/.bootstrap"
+
+for script in 00_homebrew.sh 10_defaults.sh 20_symlinks.sh 90_finish.sh; do
+  SCRIPT_PATH="$BOOTSTRAP_DIR/$script"
+  if [ -f "$SCRIPT_PATH" ]; then
+    echo "[BOOTSTRAP] Running $script..."
+    /bin/zsh "$SCRIPT_PATH"
+  else
+    echo "[BOOTSTRAP] Skipping $script (not found)"
+  fi
+done
+
+echo "[BOOTSTRAP] All bootstrap steps complete."

--- a/README.md
+++ b/README.md
@@ -99,3 +99,15 @@ To back up conflicting files during a checkout:
 mkdir -p .dotfiles-backup
 dotfiles checkout 2>&1 | grep -E "^\s+" | awk '{print $1}' | xargs -I{} mv {} .dotfiles-backup/{}
 ```
+
+## Bootstrap
+
+Bootstrap scripts for setting up a fresh macOS environment are located in `~/.bootstrap/*`.
+
+To run all bootstrap steps in sequence:
+
+```sh
+chmod +x ~/.bootstrap/bootstrap.sh
+```
+
+This will execute 00_homebrew.sh, 10_defaults.sh, 20_symlinks.sh, and 90_finish.sh in order, skipping any missing scripts.


### PR DESCRIPTION
This pull request introduces a new bootstrap system for setting up a fresh macOS environment and updates corresponding instructions in the `README.md`.

### Bootstrap system:

* [`.bootstrap/bootstrap.sh`](diffhunk://#diff-f42c4047d14572f06ce4551213b9300be3475014e33786c74ecf2ee5d42fe35fR1-R18): Added a new script to automate the setup process by executing a sequence of predefined scripts (`00_homebrew.sh`, `10_defaults.sh`, `20_symlinks.sh`, and `90_finish.sh`). The script handles missing files gracefully and provides progress messages.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R113): Added a "Bootstrap" section with instructions on how to use the new bootstrap script to set up a macOS environment. This includes details about script execution and handling of missing scripts.