### PR TITLE
Update ticket presentation and created project for LLM context using …

### DIFF
--- a/.claude/commands/fs-project.md
+++ b/.claude/commands/fs-project.md
@@ -1,0 +1,64 @@
+---
+description: Look up a Freshservice project task and its notes
+argument-hint: <task_key>
+---
+
+Look up a Freshservice project task by its display key from the
+SQ2 data warehouse. Show task details and notes.
+
+**Task key:** `$ARGUMENTS`
+
+## Connection
+
+- Credentials: `~/.config/padsql/.env.sq2` (1Password CLI)
+- Server: `SQ2`
+- Database: `Fivetran`
+- Resolve credentials with `op run`:
+  ```
+  op run --env-file ~/.config/padsql/.env.sq2 -- \
+    bash -c 'sqlcmd -S SQ2 -d Fivetran \
+      -U "$PADSQL_USER" -P "$PADSQL_PASSWORD" \
+      -s "|" -W -i /tmp/fs-project-query.sql'
+  ```
+
+## Workflow
+
+1. Validate that a task key was provided (e.g., IS26-123).
+   If missing or invalid, ask for one.
+
+2. **Query 1 — Task details.** Write this SQL to a temp
+   file and execute via sqlcmd. Replace `<KEY>` with the
+   task key:
+   ```sql
+   SELECT *
+   FROM freshservice_extensibility.project_task
+   WHERE task_key = '<KEY>'
+   ```
+
+3. **Query 2 — Task notes.** Write this SQL to a temp
+   file and execute via sqlcmd. Replace `<KEY>` with the
+   task key:
+   ```sql
+   SELECT
+       p.[key] AS project_key,
+       n.user_email_id AS note_author,
+       n.body AS note_body,
+       n.attachments AS note_attachments,
+       n.created_at AS note_created_at
+   FROM freshservice.custom_stage_project_task AS pt
+       INNER JOIN freshservice.custom_stage_project AS p
+           ON pt.project_id = p.id
+       LEFT JOIN freshservice.custom_stage_project_task_note AS n
+           ON pt.id = n.task_id
+   WHERE pt.display_key = '<KEY>'
+   ORDER BY n.created_at
+   ```
+
+## Execution notes
+
+- Write SQL to `/tmp/fs-project-details.sql` and
+  `/tmp/fs-project-notes.sql` to avoid shell quoting
+  issues with single quotes in SQL
+- Use `-s "|" -W` flags for pipe-delimited, trimmed output
+- Run both queries — task details first, then notes
+- Strip HTML tags from note_body

--- a/.claude/commands/fs-ticket.md
+++ b/.claude/commands/fs-ticket.md
@@ -69,18 +69,6 @@ warehouse. Show ticket details and conversation history.
    ORDER BY c.created_at
    ```
 
-4. **Present results:**
-   - Show ticket details as a structured summary, not a
-     raw table — pull out key fields clearly
-   - Show conversations in chronological order with
-     author, direction (incoming/outgoing), visibility
-     (public/private), and timestamp
-   - Strip HTML tags from body_text if present
-   - If no ticket found, say so
-   - If no conversations found, note that only
-     Information Solutions workspace conversations are
-     synced to the warehouse
-
 ## Execution notes
 
 - Write SQL to `/tmp/fs-ticket-details.sql` and
@@ -89,3 +77,4 @@ warehouse. Show ticket details and conversation history.
 - Use `-s "|" -W` flags for pipe-delimited, trimmed output
 - Run both queries — ticket details first, then
   conversations
+- Strip HTML tags from body_text


### PR DESCRIPTION

This pull request adds a new command specification for looking up Freshservice project tasks and their notes, and makes minor improvements to the existing Freshservice ticket command documentation. The main focus is on providing a clear workflow and execution instructions for querying project tasks and their associated notes from the data warehouse.

New Freshservice project task lookup command:

* Added `.claude/commands/fs-project.md` with detailed instructions for looking up a Freshservice project task and its notes, including SQL queries, credential handling, and output formatting.

Improvements to Freshservice ticket command documentation:

* Clarified execution notes in `.claude/commands/fs-ticket.md` to explicitly mention stripping HTML tags from `body_text` in conversation results.
* Removed redundant details about result presentation from `.claude/commands/fs-ticket.md` to streamline the documentation.