### PR TITLE
Add default to pull defaults back from IDE

### DIFF
--- a/.Brewfile
+++ b/.Brewfile
@@ -101,6 +101,8 @@ cask "loom"
 cask "maccy"
 # Speech-to-text transcription application
 cask "macwhisper"
+# Markdown editor — default handler for .md (see .bootstrap/10_defaults.sh)
+cask "markedit"
 # Background Audio Removal
 cask "krisp"
 # Multi-platform web browser

--- a/.bootstrap/10_defaults.sh
+++ b/.bootstrap/10_defaults.sh
@@ -15,6 +15,23 @@ duti -s com.colliderli.iina public.mpeg-4-audio all
 duti -s com.colliderli.iina public.mpeg-4 all
 duti -s com.colliderli.iina com.microsoft.waveform-audio all
 duti -s com.colliderli.iina public.m3u-playlist all
+
+# JSON → OK JSON
+# Set both the UTI and the extension: JetBrains IDEs re-register their
+# file claims on update and steal these back, so re-running this script
+# restores them.
+duti -s net.shinystone.OKJSON public.json all
+duti -s net.shinystone.OKJSON .json all
+
+# Markdown → MarkEdit
+duti -s app.cyan.markedit net.daringfireball.markdown all
+duti -s app.cyan.markedit .md all
+duti -s app.cyan.markedit .markdown all
+
+# Config / data files → VS Code (reclaimed from PyCharm)
+duti -s com.microsoft.VSCode .yaml all
+duti -s com.microsoft.VSCode .yml all
+duti -s com.microsoft.VSCode .xml all
 echo "[defaults] duti assignments done."
 
 # ====== TRACKPAD =====


### PR DESCRIPTION
## Summary

Reclaim macOS default file handlers that PyCharm steals on JetBrains updates, by pinning them in the bootstrap process.

## Changes

- `.bootstrap/10_defaults.sh`: expand the duti block: `.json` → OK JSON, `.md`/`.markdown` → MarkEdit, `.yaml`/`.yml`/`.xml` → VS Code. JSON and Markdown are set at both the UTI and extension level since JetBrains re-registers its claims on update; re-running the script restores everything.
- `.Brewfile`: add `cask "markedit"`
