### PR TITLE
perf(zsh): halve shell startup from ~360ms to ~175ms

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -4,7 +4,13 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 # Prefer Homebrew Ruby over macOS system Ruby
 export PATH="/opt/homebrew/opt/ruby/bin:/usr/local/opt/ruby/bin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
-export PATH="$(ruby -r rubygems -e 'puts Gem.bindir'):$PATH"
+# Homebrew's gem bindir is version-pinned (e.g. .../gems/4.0.0/bin) and the
+# version segment moves on `brew upgrade ruby`, so it can't be hardcoded.
+# Glob instead of shelling out to Ruby: (Nn[-1]) = nullglob, numeric sort,
+# newest match only. Numeric sort matters -- lexically 4.9.0 > 4.10.0.
+gembin=(/opt/homebrew/lib/ruby/gems/*/bin(Nn[-1]))
+(( $#gembin )) && export PATH="$gembin[1]:$PATH"
+unset gembin
 
 eval "$(starship init zsh)"
 
@@ -21,18 +27,26 @@ alias ccgc='claude -p "/gc" --model haiku --allowedTools "Bash(git diff:*)" "Bas
 # pyenv initialization
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init --path)"
+# `pyenv init -` emits everything `pyenv init --path` emits and more, so
+# running both ran the whole init twice -- including `pyenv rehash` twice
+# at ~75-113ms a call. Dropping --path leaves PATH byte-for-byte identical.
 eval "$(pyenv init -)"
 
 
 # Auto completion 
 if type brew &>/dev/null; then
-    FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
+    # $HOMEBREW_PREFIX is already exported by `brew shellenv` above -- no
+    # need to fork `brew --prefix` again here or below.
+    FPATH=$HOMEBREW_PREFIX/share/zsh-completions:$FPATH
 
     autoload -Uz compinit
-    compinit
+    if [[ -n ~/.zcompdump(#qN.mh-24) ]]; then
+        compinit -C   # dump is <24h old: trust it, skip the security audit
+    else
+        compinit      # audit and rebuild at most once a day
+    fi
 fi
 # Auto suggestions
-source "$(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
+source "$HOMEBREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
 # Syntax highlighting
-source "$(brew --prefix)/opt/zsh-fast-syntax-highlighting/share/zsh-fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
+source "$HOMEBREW_PREFIX/opt/zsh-fast-syntax-highlighting/share/zsh-fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"


### PR DESCRIPTION
## What

Cuts zsh startup roughly in half: **~360 ms → ~175 ms** (median of 6 warm runs, cold run discarded).

zsh itself is not slow — `zsh -f -i -c exit` with no rc files at all is ~6 ms. Essentially the entire launch cost was these 38 lines.

## Where the time went

| Line | Cost | Cause |
|---|---|---|
| `pyenv init` ×2 | ~245 ms | `pyenv init -` output is a **superset** of `pyenv init --path` — the whole init ran twice, including `pyenv rehash` twice at ~75–113 ms per call |
| `ruby -e 'puts Gem.bindir'` | ~51 ms | a full Ruby VM to locate one binary, `colorls` |
| `$(brew --prefix)` ×3 | ~30 ms | `$HOMEBREW_PREFIX` is already exported by `brew shellenv` on line 3 |
| `compinit` | ~23 ms | ~14 ms of it was `compaudit` re-running; the dump itself was already cached |

The largest single fix is a deletion.

## Measured

Seven runs per variant via `ZDOTDIR` for an apples-to-apples comparison, cold run discarded, median reported:

| Variant | Median | Δ |
|---|---|---|
| `main` | 360.1 ms | — |
| gem-path change only | 317.0 ms | −43 ms |
| pyenv change only | 200.8 ms | −159 ms |
| **both (this PR)** | **175.1 ms** | **−185 ms (~51%)** |

## Correctness

`PATH` is **byte-for-byte identical to `main`** — 29 entries, `~/.pyenv/shims` still first. Verified by building `PATH` both ways in a clean `zsh -f` and diffing entry by entry.

Two behaviours were treated as non-negotiable and gated explicitly:

- **`colorls` works** — resolves to `/opt/homebrew/lib/ruby/gems/4.0.0/bin/colorls`, executes, and the `ls` alias works in a real interactive shell.
- **pyenv is what comes up** — `python`, `python3`, `pip` all resolve through `~/.pyenv/shims/`; `pyenv` remains a shell function; `pyenv version` still reports `system`.

Completions, autosuggestions, and fast-syntax-highlighting all load; the file sources with no warnings.

## Notes on the tradeoffs taken

- **`pyenv rehash` is kept.** `pyenv init - --no-rehash` would save another ~75 ms but changes when shims regenerate after `pyenv install` or a `pip install` that adds a console script. Not worth it.
- **The gem bindir glob uses `(Nn[-1])`, not `(N)`.** The `n` (numeric sort) qualifier is load-bearing: `/opt/homebrew/lib/ruby/gems/` is a real root-owned directory, not a Cellar symlink, so old version dirs persist across `brew upgrade ruby`. Under zsh's default lexical sort a future `4.10.0` would lose to `4.9.0`. Verified against a synthetic `4.9.0`/`4.10.0`/`4.2.0` tree.
- **Known residual assumption:** unlike `Gem.bindir`, the glob ignores `GEM_HOME`. It is currently unset and unreferenced in any shell rc file. If it is ever set, this line diverges silently and `colorls` is what breaks.
- **`compinit -C` runs behind a 24-hour guard**, so roughly one shell per day pays the full audit (~14 ms extra, not the ~230 ms cold rebuild).

## Deliberately left on the table

- `pyenv init - --no-rehash` — ~75 ms
- Inlining `brew shellenv` as static exports — ~28 ms
- Caching `starship init zsh` output — ~23 ms, would need a generated file
- Inlining pyenv's init statically — the last ~76 ms, but means owning pyenv's init contract

## Test plan

- [x] `PATH` diffed entry-by-entry against `main` — identical
- [x] `colorls` resolves and executes; `ls` alias works in `zsh -i`
- [x] `python`/`python3`/`pip` resolve through pyenv shims
- [x] `pyenv` is a shell function; `pyenv version` unchanged
- [x] `pyenv init -` still emits `rehash`
- [x] completions (`_comps[git]`), autosuggestions, syntax highlighting load
- [x] `zsh -c 'source ~/.zshrc'` clean, no warnings
- [x] timing measured before/after on each change independently and combined

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QS7HdgNDokm4DoGFWfSkCL
